### PR TITLE
debian/control: Build-Depends: libsqlite3-dev, sqlite3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,5 +14,5 @@ Standards-Version: 3.9.4
 
 Package: mediabrowser
 Architecture: all
-Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}, libsqlite3-dev, sqlite3
 Description: Media Browser Server is a home media server built on top of other popular open source technologies such as Service Stack, jQuery, jQuery mobile, and Mono. It features a REST-based api with built-in documention to facilitate client development. We also have client libraries for our api to enable rapid development.


### PR DESCRIPTION
Trying to force depends on libsqlite3.